### PR TITLE
애플 실리콘 대응 - icalfileset.c 컴파일 오류 수정

### DIFF
--- a/src/libicalss/icalfileset.c
+++ b/src/libicalss/icalfileset.c
@@ -336,9 +336,37 @@ static char *shell_quote(const char *s)
 
 #endif
 
+/*   ** Function return value meaning
+ * -1 cannot open source file
+ * -2 cannot open destination file
+ * 0 Success
+ */
+int File_Copy (char FileSource [], char FileDestination [])
+{
+    int   c;
+    FILE *stream_R;
+    FILE *stream_W;
+    
+    stream_R = fopen (FileSource, "r");
+    if (stream_R == NULL)
+        return -1;
+    stream_W = fopen (FileDestination, "w");   //create and write to file
+    if (stream_W == NULL)
+    {
+        fclose (stream_R);
+        return -2;
+    }
+    while ((c = fgetc(stream_R)) != EOF)
+        fputc (c, stream_W);
+    fclose (stream_R);
+    fclose (stream_W);
+    
+    return 0;
+}
+
 icalerrorenum icalfileset_commit(icalset *set)
 {
-    char tmp[MAXPATHLEN];
+    char destPath[MAXPATHLEN];
     char *str;
     icalcomponent *c;
     size_t write_size = 0;
@@ -361,27 +389,17 @@ icalerrorenum icalfileset_commit(icalset *set)
 #if !defined(_WIN32)
         char *quoted_file = shell_quote(fset->path);
 
-        snprintf(tmp, MAXPATHLEN, "cp '%s' '%s.bak'", fset->path, fset->path);
+        snprintf(destPath, MAXPATHLEN, "%s.bak", fset->path);
         free(quoted_file);
 #else
-        snprintf(tmp, MAXPATHLEN, "copy %s %s.bak", fset->path, fset->path);
+        snprintf(destPath, MAXPATHLEN, "%s.bak", fset->path);
 #endif
 
-#if !defined(_WIN32_WCE)
-        if (system(tmp) < 0) {
-#else
-
-        wtmp = wce_mbtowc(tmp);
-
-        if (CreateProcess(wtmp, L"", NULL, NULL, FALSE, 0, NULL, NULL, NULL, &pi)) {
-#endif
+        if (File_Copy(fset->path, destPath) < 0) {
             icalerror_set_errno(ICAL_FILE_ERROR);
             return ICAL_FILE_ERROR;
         }
     }
-#if defined(_WIN32_WCE)
-    free(wtmp);
-#endif
 
     if (lseek(fset->fd, 0, SEEK_SET) < 0) {
         icalerror_set_errno(ICAL_FILE_ERROR);


### PR DESCRIPTION
## 이슈
- [XbICalendar](https://github.com/worksmobile/XbICalendar)에서 libical 바이너리 빌드 시 `'system' is unavailable: not available on iOS` 오류 발생

## 원인
- [https://github.com/libical/libical/issues/312](https://github.com/libical/libical/issues/312)에서 인지하고 있으나 새 버전이 나오고 있지 않아 직접 수정 필요

## 수정 사항
- https://github.com/libical/libical/issues/312 내 workaround를 참고하여 메소드를 추가하고 `icalfileset_commit` 메소드의 구현 내역 수정

## 참고 사항
- 이전에 검토할때는 이쪽에서 문제가 생겨 수정을 미리 해뒀었는데, [최근 검토](https://github.com/worksmobile/XbICalendar/pull/1)에서는 에러가 발생하지 않아 별도 포크없이 libical 레포의 최근 버전 태그를 바라보도록 수정했었는데요. 이는 클론했던 레포를 계속 사용하고 있어서 문제가 발생하지 않았던 것이었어서 해당 수정 반영이 필요해졌습니다.
- 버전 선택은 빌드에 문제가 없는 버전인 `v2.0.0`을 베이스 브랜치로 선택했습니다.
  - `v3.0.18`에서는 아래와 같은 문제가 발생하여 현재 빌드하기 힘든 것으로 확인했습니다.
    ```
    [ 56%] Linking C executable ../../bin/ical-glib-src-generator 
    ld: building for 'iOS', but linking in dylib (/opt/homebrew/Cellar/glib/2.80.2/lib/libglib-2.0.0.dylib) built for 'macOS'
    ```
